### PR TITLE
Add properties to FCM App to allow operation without env vars

### DIFF
--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -53,6 +53,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_4_1_0_updates')
     add_rpush_migration('rpush_4_1_1_updates')
     add_rpush_migration('rpush_4_2_0_updates')
+    add_rpush_migration('rpush_7_1_0_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_7_1_0_updates.rb
+++ b/lib/generators/templates/rpush_7_1_0_updates.rb
@@ -1,0 +1,12 @@
+class Rpush710Updates < ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  def self.up
+    add_column :rpush_apps, :firebase_project_id, :string
+    add_column :rpush_apps, :json_key, :text
+  end
+
+  def self.down
+    remove_column :rpush_apps, :firebase_project_id
+    remove_column :rpush_apps, :json_key
+  end
+end
+

--- a/lib/rpush/version.rb
+++ b/lib/rpush/version.rb
@@ -1,8 +1,8 @@
 module Rpush
   module VERSION
     MAJOR = 7
-    MINOR = 0
-    TINY = 1
+    MINOR = 1
+    TINY = 0
     PRE = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".").freeze


### PR DESCRIPTION
Work done by @nigimaxx to allow configuration using the RPush Apps model instead of ENV variables. This makes it more consistent with RPush's design, and allows multiple FCM apps to be configured.