### PR TITLE
Do not set android->notification unless explicit

### DIFF
--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -66,9 +66,8 @@ module Rpush
           end
 
           def android_config
-            json = {
-              'notification' => android_notification,
-            }
+            json = {}
+            json['notification'] = android_notification if notification
             json['collapse_key'] = collapse_key if collapse_key
             json['priority'] = priority_str if priority
             json['ttl'] = "#{expiry}s" if expiry


### PR DESCRIPTION
Do not set android->notification in the request body unless explicitly states as this would otherwise cause data messages to not get processed when the app is running in the background.